### PR TITLE
Adds support for additional sources 

### DIFF
--- a/cthulhu
+++ b/cthulhu
@@ -53,7 +53,7 @@ def main():
 
     # creates /home/$USER/.config/cthulhu/ (not needed for now)
     """ os.makedirs(os.path.expanduser('~')+'/.config/cthulhu', exist_ok=True)
-    cache_dir = os.path.expanduser('~')+'/.config/cthulhu' """
+    config_dir = os.path.expanduser('~')+'/.config/cthulhu' """
 
     # parsing arguments
     args = sys.argv

--- a/cthulhu
+++ b/cthulhu
@@ -61,6 +61,8 @@ def main():
     parsed_args = parse_args(args)
     print(parsed_args)
 
+    # TODO get source
+
     # change player to vlc if specified by --vlc
     if parsed_args['--vlc'][0] == True and vlc_exists:
         player = 'vlc'
@@ -77,8 +79,9 @@ def main():
     selection  = select_torrent(results, display_count=20)
     magnet_link = get_magnet_link(results, selection)
 
+    # spits out magnet link only (if specified by --get-magnet)
+    # else streams torrent like regular
     if parsed_args['--get-magnet'][0] == False:
-        
         while True:
             # play selected torrent in peerflix
             os.system(f'peerflix --{player} {list_mode} \'{magnet_link}\'')

--- a/cthulhu
+++ b/cthulhu
@@ -10,7 +10,6 @@ if the code works, it works.
 # TODO add config file for setting defaults 
 # TODO implement fullscreen flag
 # TODO spit out magnet link automatically when peerflix not detected 
-# TODO change how peerflix is detected
 
 import os
 import sys
@@ -213,7 +212,7 @@ def parse_args(args):
     return (options, query, source)
 
 def get_source(source_name):
-    
+
     if source_name == '1337x':
         source = ThirteenThirtySevenX()
     elif source_name == 'nyaa':

--- a/cthulhu
+++ b/cthulhu
@@ -8,6 +8,7 @@ if the code works, it works.
 '''
 
 # TODO add config file for setting defaults 
+# TODO implement fullscreen flag
 # TODO add ground work for adding different sources 
 # TODO spit out magnet link automatically when peerflix not detected 
 # TODO change how peerflix is detected
@@ -32,8 +33,8 @@ except ImportError:
 
 # can be changed to a mirror, might automate switching mirrors if 
 # server doesn't respond or something
-base_url = 'https://1337x.wtf'
 
+#base_url = 'https://1337x.wtf'
 responses = []
 
 def main():
@@ -58,10 +59,19 @@ def main():
 
     # parsing arguments
     args = sys.argv
-    parsed_args = parse_args(args)
-    print(parsed_args)
+    temp = parse_args(args)
+    parsed_args = temp[0]
 
     # TODO get source
+    # hardcoded for now
+    source = get_source('1337x')
+    get_responses = source.get_responses
+    parse_responses = source.parse_responses
+    get_magnet_link = source.get_magnet_link
+
+    # makes a search based on the returned query from parse_args(args)
+    query = temp[1]
+    search(get_responses, query)
 
     # change player to vlc if specified by --vlc
     if parsed_args['--vlc'][0] == True and vlc_exists:
@@ -111,10 +121,8 @@ def main():
     else: 
         print(magnet_link)
  
-# 1337x
-def parse_args(args):
 
-    # TODO implement fullscreen flag
+def parse_args(args):
 
     options = {
         '--no-clean': [False, None],
@@ -131,7 +139,6 @@ def parse_args(args):
         if options[key][1] is not None:
             flags.append(options[key][1])
 
-
     searched = False
 
     def get_query():
@@ -141,16 +148,15 @@ def parse_args(args):
                 query += args[i]
                 query += '+'     
         if query != '':
-            # non-agnostic search call
-            search(query)
+            searched = True
+            return query
         else:
             query = input('Enter search query: ')
-            # non-agnostic search call
-            search(query)
             searched = True
+            return query
 
     if len(args) == 1:
-        get_query()
+        query = get_query()
         searched = True
     else:
 
@@ -175,10 +181,15 @@ def parse_args(args):
         
         
     if not searched:
-        get_query()
+        query = get_query()
 
-    return options
+    return (options, query)
 
+# TODO add sources, also option for changing sources
+def get_source(source_name):
+    if source_name == '1337x':
+        source = ThirteenThirtySevenX()
+    return source
 
 def select_torrent(results, display_count):
 
@@ -210,80 +221,93 @@ def select_torrent(results, display_count):
 
     return selection
 
-# 1337x
-def search(query):
+
+def search(get_responses, query):
 
     while len(query) < 3:
         print('Please make sure your query contains at least 3 characters')
         query = input('\nEnter search query: ')
-    print('Fetching torrents…', end=' ')
+    print('Fetching torrents…')
 
-    print()
-    responses.append(requests.get(f'{base_url}/category-search/{query}/Movies/1/').text)
-    responses.append(requests.get(f'{base_url}/category-search/{query}/TV/1/').text)
-    responses.append(requests.get(f'{base_url}/category-search/{query}/Anime/1/').text)
+    get_responses(query)
     print()
 
-# 1337x
-def parse_responses():
 
-    packed_data = []
-    titles = []
-    seeders = []
-    leechers = []
-    upload_dates = []
-    file_sizes = []
-    links = []
+#
+# Source Classes
+#
 
-    flag = 0
-    num_response = 0
-    for response in responses:
-        
-        num_response += 1
-        
-        root = html.fromstring(response).xpath('//tbody/tr')
+class ThirteenThirtySevenX:
 
-        if not root:
-            flag += 1
+    url = 'https://1337x.wtf'
 
-        for tr in root:
-            # title
-            tmp_title = tr.xpath('.//td//a/text()')[0]
+    @staticmethod 
+    def get_responses(query):
+        base = __class__.url
+        responses.append(requests.get(f'{base}/category-search/{query}/Movies/1/').text)
+        responses.append(requests.get(f'{base}/category-search/{query}/TV/1/').text)
+        responses.append(requests.get(f'{base}/category-search/{query}/Anime/1/').text)
 
-            # torrent link
-            tmp_torrent_link = tr.xpath('.//td//a/@href')[1]
+    @staticmethod 
+    def parse_responses():
 
-            # [seeders, leechers, upload date, size]
-            tmp_additional_data = tr.xpath('.//td/text()')
+        packed_data = []
+        titles = []
+        seeders = []
+        leechers = []
+        upload_dates = []
+        file_sizes = []
+        links = []
 
-            titles.append(tmp_title)
-            seeders.append(int(tmp_additional_data[0]))
-            leechers.append(int(tmp_additional_data[1]))
-            upload_dates.append(tmp_additional_data[2])
-            file_sizes.append(tmp_additional_data[3])
-            links.append(tmp_torrent_link)
+        flag = 0
+        num_response = 0
+        for response in responses:
+            
+            num_response += 1
+            
+            root = html.fromstring(response).xpath('//tbody/tr')
 
-    if flag == num_response:
-        print('No results found.\n')
-        exit()
+            if not root:
+                flag += 1
 
-    for i in range(len(titles)):
-        packed_data.append([titles[i], links[i], upload_dates[i], seeders[i], leechers[i], file_sizes[i]])
+            for tr in root:
+                # title
+                tmp_title = tr.xpath('.//td//a/text()')[0]
 
-    # sort by seeder count
-    sorted_data = sorted(packed_data, key=itemgetter(3), reverse=True)
+                # torrent link
+                tmp_torrent_link = tr.xpath('.//td//a/@href')[1]
 
-    return sorted_data
+                # [seeders, leechers, upload date, size]
+                tmp_additional_data = tr.xpath('.//td/text()')
 
-# 1337x
-def get_magnet_link(results, selection):
-    target_link = f'{base_url}{results[int(selection)-1][1]}'
-    magnet_response = requests.get(target_link).text
+                titles.append(tmp_title)
+                seeders.append(int(tmp_additional_data[0]))
+                leechers.append(int(tmp_additional_data[1]))
+                upload_dates.append(tmp_additional_data[2])
+                file_sizes.append(tmp_additional_data[3])
+                links.append(tmp_torrent_link)
 
-    magnet_link = html.fromstring(magnet_response).xpath('//li/a/@href')[29]
+        if flag == num_response:
+            print('No results found.\n')
+            exit()
 
-    return magnet_link
+        for i in range(len(titles)):
+            packed_data.append([titles[i], links[i], upload_dates[i], seeders[i], leechers[i], file_sizes[i]])
 
+        # sort by seeder count
+        sorted_data = sorted(packed_data, key=itemgetter(3), reverse=True)
+
+        return sorted_data
+  
+    @staticmethod 
+    def get_magnet_link(results, selection):
+        base = __class__.url
+        target_link = f'{base}{results[int(selection)-1][1]}'
+        magnet_response = requests.get(target_link).text
+
+        magnet_link = html.fromstring(magnet_response).xpath('//li/a/@href')[29]
+
+        return magnet_link
 
 
 if __name__ == '__main__':

--- a/cthulhu
+++ b/cthulhu
@@ -9,7 +9,6 @@ if the code works, it works.
 
 # TODO add config file for setting defaults 
 # TODO implement fullscreen flag
-# TODO add ground work for adding different sources 
 # TODO spit out magnet link automatically when peerflix not detected 
 # TODO change how peerflix is detected
 
@@ -34,7 +33,6 @@ except ImportError:
 # can be changed to a mirror, might automate switching mirrors if 
 # server doesn't respond or something
 
-#base_url = 'https://1337x.wtf'
 responses = []
 
 def main():
@@ -62,24 +60,27 @@ def main():
     temp = parse_args(args)
     parsed_args = temp[0]
 
-    # TODO get source
-    # hardcoded for now
-    source = get_source('1337x')
-    get_responses = source.get_responses
-    parse_responses = source.parse_responses
-    get_magnet_link = source.get_magnet_link
+    # get source
+    if parsed_args['--source'][0]:
+        source = temp[2]
+    else:
+        source = '1337x' # change to read from config
+    source_class = get_source(source)
+    get_responses = source_class.get_responses
+    parse_responses = source_class.parse_responses
+    get_magnet_link = source_class.get_magnet_link
 
     # makes a search based on the returned query from parse_args(args)
     query = temp[1]
     search(get_responses, query)
 
     # change player to vlc if specified by --vlc
-    if parsed_args['--vlc'][0] == True and vlc_exists:
+    if parsed_args['--vlc'][0] and vlc_exists:
         player = 'vlc'
 
     # default is just to play all files in torrent sorted by name
     list_mode = '-a'
-    if parsed_args['--list'][0] == True:
+    if parsed_args['--list'][0]:
         list_mode = '-l'
 
     # parsing html responses from search query
@@ -125,6 +126,7 @@ def main():
 def parse_args(args):
 
     options = {
+        '--source': [False, '-s'],
         '--no-clean': [False, None],
         '--get-magnet': [False, None],
         '--vlc': [False, None],
@@ -132,6 +134,8 @@ def parse_args(args):
         '--list': [False, '-l'],
         '--fullscreen': [False, '-f'],
     }
+
+    sources = ['1337x', 'nyaa']
 
     flags = []
     for key in options:
@@ -161,12 +165,18 @@ def parse_args(args):
     else:
 
         if '--help' in args or '-h' in args:
+            print()
             print('Usage: cthulhu [options] search-query\n')
             print('Options:')
+            print(' {:15}\t{}'.format('-s, --source', 'Changes to specified source'))
             print(' {:15}\t{}'.format('--no-clean', 'Avoids deleting the torrent cache'))
             print(' {:15}\t{}'.format('--get-magnet', 'Prints the torrent magnet link'))
-            print(' {:15}\t{}'.format('--vlc', 'Sets the player to vlc'))
             print(' {:15}\t{}'.format('-l, --list', 'Lists all files in a torrent for selection'))
+            print(' {:15}\t{}'.format('--vlc', 'Sets the player to vlc'))
+            print()
+            print('Sources:')
+            for source in sources:
+                print(' {}'.format(source))
             print()
             exit()
 
@@ -179,16 +189,38 @@ def parse_args(args):
                 except KeyError:
                     options[flags[i-1]][0] = True
         
+        # sets source
+        source = ''
+        if '--source' in args or '-s' in args:
+            def parse_source(str):
+                if args.index(str) == len(args)-1:
+                    print('No source specified… Use \'-h\' to see a list of valid sources.')
+                    exit()
+                elif args[args.index(str)+1].lower() in sources:
+                    source = args[args.index(str)+1].lower()
+                    return source
+                else:
+                    print('Invalid source… Use \'-h\' to see a list of valid sources.')
+                    exit()
+
+            try:
+                source = parse_source('--source')
+            except ValueError:
+                source = parse_source('-s')
+
         
     if not searched:
-        query = get_query()
+        query = get_query().replace(source+'+', '')
+        
 
-    return (options, query)
+    return (options, query, source)
 
-# TODO add sources, also option for changing sources
 def get_source(source_name):
     if source_name == '1337x':
         source = ThirteenThirtySevenX()
+    elif source_name == 'nyaa':
+        source = Nyaa()
+    print('\nSource: '+ source_name)
     return source
 
 def select_torrent(results, display_count):
@@ -221,9 +253,7 @@ def select_torrent(results, display_count):
 
     return selection
 
-
 def search(get_responses, query):
-
     while len(query) < 3:
         print('Please make sure your query contains at least 3 characters')
         query = input('\nEnter search query: ')
@@ -306,6 +336,90 @@ class ThirteenThirtySevenX:
         magnet_response = requests.get(target_link).text
 
         magnet_link = html.fromstring(magnet_response).xpath('//li/a/@href')[29]
+
+        return magnet_link
+
+class Nyaa:
+
+    url = 'https://nyaa.si'
+
+    @staticmethod 
+    def get_responses(query):
+        base = __class__.url
+        responses.append(requests.get(f'{base}/?f=0&c=1_0&q={query}&s=seeders&o=desc').text)
+        responses.append(requests.get(f'{base}/?f=0&c=2_0&q={query}&s=seeders&o=desc').text)
+        responses.append(requests.get(f'{base}/?f=0&c=4_0&q={query}&s=seeders&o=desc').text)
+
+    @staticmethod 
+    def parse_responses():
+
+        packed_data = []
+        titles = []
+        seeders = []
+        leechers = []
+        upload_dates = []
+        file_sizes = []
+        links = []
+
+        flag = 0
+        num_response = 0
+        for response in responses:
+            
+            num_response += 1
+            
+            root = html.fromstring(response).xpath('//tbody/tr')
+
+            if not root:
+                flag += 1
+
+            # if anyone knows a better way to parse the html on nyaa.si, please lmk
+            # im literally crying rn (cthulhu -s nyaa naruto)
+            for tr in root:
+                # title
+                tmp_title = tr.xpath('.//td//a/text()').pop()
+                
+                # torrent link
+                tmp_torrent_link = tr.xpath('.//td//a/@href').pop()
+
+
+                temp = tr.xpath('.//td/text()')
+                temp.pop()
+
+                # leechers
+                tmp_leechers = temp.pop()
+
+                # seeders
+                tmp_seeders = temp.pop()
+
+                # upload dates
+                tmp_upload_date = temp.pop().split()[0]
+
+                # file sizes
+                tmp_file_size = temp.pop()
+
+                titles.append(tmp_title)
+                seeders.append(tmp_seeders)
+                leechers.append(tmp_leechers)
+                upload_dates.append(tmp_upload_date)
+                file_sizes.append(tmp_file_size)
+                links.append(tmp_torrent_link)
+
+        if flag == num_response:
+            print('No results found.\n')
+            exit()
+
+        for i in range(len(titles)):
+            packed_data.append([titles[i], links[i], upload_dates[i], seeders[i], leechers[i], file_sizes[i]])
+
+        # sort by seeder count
+        sorted_data = sorted(packed_data, key=itemgetter(3), reverse=True)
+
+        return sorted_data
+  
+    @staticmethod 
+    def get_magnet_link(results, selection):
+        
+        magnet_link = results[int(selection)-1][1]
 
         return magnet_link
 

--- a/cthulhu
+++ b/cthulhu
@@ -59,13 +59,15 @@ def main():
     # parsing arguments
     args = sys.argv
     parsed_args = parse_args(args)
+    print(parsed_args)
 
     # change player to vlc if specified by --vlc
-    if 'vlc' in parsed_args and vlc_exists:
+    if parsed_args['--vlc'][0] == True and vlc_exists:
         player = 'vlc'
 
+    # default is just to play all files in torrent sorted by name
     list_mode = '-a'
-    if 'list' in parsed_args:
+    if parsed_args['--list'][0] == True:
         list_mode = '-l'
 
     # parsing html responses from search query
@@ -75,7 +77,7 @@ def main():
     selection  = select_torrent(results, display_count=20)
     magnet_link = get_magnet_link(results, selection)
 
-    if not 'get-magnet' in parsed_args:
+    if parsed_args['--get-magnet'][0] == False:
         
         while True:
             # play selected torrent in peerflix
@@ -88,7 +90,7 @@ def main():
                 break
 
         # cleans /tmp/webtorrent directory unless specified by --no-clean
-        if not 'no-clean' in parsed_args:
+        if parsed_args['--no-clean'][0] == False:
             def get_size(folder: str) -> int:  # st_blocks * 512 preferred over st_size because the latter
                                                # calculates the full allocated size even if files not downloaded yet.
                 return sum(p.stat().st_blocks * 512 for p in Path(folder).rglob('*'))
@@ -109,110 +111,114 @@ def main():
 # 1337x
 def parse_args(args):
 
-    parsed_args = []
-
     # TODO implement fullscreen flag
 
-    flags = ['-h', '--help', '--fast', '-m', '--movie', '-s', '--show', '-a', '--anime', 
-    '--no-clean', '--get-magnet', '--vlc', '-l', '--list']
+    options = {
+        '--no-clean': [False, None],
+        '--get-magnet': [False, None],
+        '--vlc': [False, None],
+        '--mpv': [False, None],
+        '--list': [False, '-l'],
+        '--fullscreen': [False, '-f'],
+    }
+
+    flags = []
+    for key in options:
+        flags.append(key)
+        if options[key][1] is not None:
+            flags.append(options[key][1])
+
 
     searched = False
 
-    def get_query(filter='default'):
+    def get_query():
         query = ''
         for i in range(1, len(args)):
             if args[i] not in flags:
                 query += args[i]
                 query += '+'     
         if query != '':
-            search(query, filter)
+            # non-agnostic search call
+            search(query)
         else:
             query = input('Enter search query: ')
-            search(query, filter)
+            # non-agnostic search call
+            search(query)
             searched = True
 
     if len(args) == 1:
         get_query()
         searched = True
     else:
-        # -h, --help
-        if flags[0] in args or flags[1] in args:
+
+        if '--help' in args or '-h' in args:
             print('Usage: cthulhu [options] search-query\n')
             print('Options:')
-            print(' {:15}\t{}'.format('--fast', 'Searches without any category filter (faster responses)'))
-            print(' {:15}\t{}'.format('-m, --movie', 'Only searches through Movie category'))
-            print(' {:15}\t{}'.format('-s, --show', 'Only searches through Show category'))
-            print(' {:15}\t{}'.format('-a, --anime', 'Only searches through Anime category'))
             print(' {:15}\t{}'.format('--no-clean', 'Avoids deleting the torrent cache'))
             print(' {:15}\t{}'.format('--get-magnet', 'Prints the torrent magnet link'))
             print(' {:15}\t{}'.format('--vlc', 'Sets the player to vlc'))
             print(' {:15}\t{}'.format('-l, --list', 'Lists all files in a torrent for selection'))
             print()
             exit()
-        # --fast
-        if flags[2] in args:
-            if not searched:
-                get_query(filter='fast')
-                searched = True
-        # -m, --movie
-        if flags[3] in args or flags[4] in args:
-            if not searched:
-                get_query(filter='movie')
-                searched = True
-        # -s, --show
-        if flags[5] in args or flags[6] in args:
-            if not searched:
-                get_query(filter='show')
-                searched = True
-        # -a, --anime
-        if flags[7] in args or flags[8] in args:
-            if not searched:
-                get_query(filter='anime')
-                searched = True
-        # --no-clean
-        if flags[9] in args:
-            parsed_args.append('no-clean')
-        # --get-magnet
-        if flags[10] in args:
-            parsed_args.append('get-magnet')
-        # --vlc
-        if flags[11] in args:
-            parsed_args.append('vlc')
-        # --list, -l
-        if flags[12] in args or flags[13] in args:
-            parsed_args.append('list')
+
+        # checks if flag is included in args and sets to True in dict
+        # at the very least, it works ¯\_(ツ)_/¯
+        for i in range(len(flags)):
+            if flags[i] in args:
+                try:
+                    options[flags[i]][0] = True
+                except KeyError:
+                    options[flags[i-1]][0] = True
         
         
     if not searched:
         get_query()
 
+    return options
 
-    return parsed_args
+
+def select_torrent(results, display_count):
+
+    if display_count>len(results):
+        display_count = len(results)
+    
+    # display data to user
+    print('\033[0m ID\t    S/L\t\tSize\t\tTorrent name\033[0m')
+    title_width = 0
+    if os.get_terminal_size()[0] > 40:
+        title_width = os.get_terminal_size()[0]-41
+    for i in range(display_count): 
+        torrent_name = results[i][0]
+        if len(torrent_name) > title_width:
+            torrent_name = torrent_name[0:title_width-1]+'…'
+        seedleech = f'(S:{results[i][3]}, L:{results[i][4]})'
+        size = results[i][5]+'  ' # couple extra spaces to make sure 3-digit sizes don't shift tabulations
+        print(' \033[1m{:>2}\033[0m\t{:>5}/{:<5}\t{}\t{}'.format(i+1, results[i][3], results[i][4], size,
+            torrent_name))
+
+    selection = input('\nSelect by ID: ')
+    try:
+        while int(selection) not in range(1, display_count+1):
+            print('ID "' + selection + '" not found, please try again.')
+            selection = input('\nSelect by ID: ')
+    except:
+        print('"' + selection + '" is not a valid ID, please try again.')
+        selection = input('\nSelect by ID: ')
+
+    return selection
 
 # 1337x
-def search(search_query, filter):
+def search(query):
 
-    while len(search_query) < 3:
+    while len(query) < 3:
         print('Please make sure your query contains at least 3 characters')
-        search_query = input('\nEnter search query: ')
+        query = input('\nEnter search query: ')
     print('Fetching torrents…', end=' ')
-    if filter == 'default':
-        print()
-        responses.append(requests.get(f'{base_url}/category-search/{search_query}/Movies/1/').text)
-        responses.append(requests.get(f'{base_url}/category-search/{search_query}/TV/1/').text)
-        responses.append(requests.get(f'{base_url}/category-search/{search_query}/Anime/1/').text)
-    elif filter == 'fast':
-        print('Displaying non-filtered results')
-        responses.append(requests.get(f'{base_url}/search/{search_query}/1/').text)
-    elif filter == 'movie':
-        print('Displaying movies only:')
-        responses.append(requests.get(f'{base_url}/category-search/{search_query}/Movies/1/').text)
-    elif filter == 'show':
-        print('Displaying shows only:')
-        responses.append(requests.get(f'{base_url}/category-search/{search_query}/TV/1/').text)
-    elif filter == 'anime':
-        print('Displaying anime only:')
-        responses.append(requests.get(f'{base_url}/category-search/{search_query}/Anime/1/').text)
+
+    print()
+    responses.append(requests.get(f'{base_url}/category-search/{query}/Movies/1/').text)
+    responses.append(requests.get(f'{base_url}/category-search/{query}/TV/1/').text)
+    responses.append(requests.get(f'{base_url}/category-search/{query}/Anime/1/').text)
     print()
 
 # 1337x
@@ -266,36 +272,6 @@ def parse_responses():
 
     return sorted_data
 
-def select_torrent(results, display_count):
-
-    if display_count>len(results):
-        display_count = len(results)
-    
-    # display data to user
-    print('\033[0m ID\t    S/L\t\tSize\t\tTorrent name\033[0m')
-    title_width = 0
-    if os.get_terminal_size()[0] > 40:
-        title_width = os.get_terminal_size()[0]-41
-    for i in range(display_count): 
-        torrent_name = results[i][0]
-        if len(torrent_name) > title_width:
-            torrent_name = torrent_name[0:title_width-1]+'…'
-        seedleech = f'(S:{results[i][3]}, L:{results[i][4]})'
-        size = results[i][5]+'  ' # couple extra spaces to make sure 3-digit sizes don't shift tabulations
-        print(' \033[1m{:>2}\033[0m\t{:>5}/{:<5}\t{}\t{}'.format(i+1, results[i][3], results[i][4], size,
-            torrent_name))
-
-    selection = input('\nSelect by ID: ')
-    try:
-        while int(selection) not in range(1, display_count+1):
-            print('ID "' + selection + '" not found, please try again.')
-            selection = input('\nSelect by ID: ')
-    except:
-        print('"' + selection + '" is not a valid ID, please try again.')
-        selection = input('\nSelect by ID: ')
-
-    return selection
-
 # 1337x
 def get_magnet_link(results, selection):
     target_link = f'{base_url}{results[int(selection)-1][1]}'
@@ -304,14 +280,6 @@ def get_magnet_link(results, selection):
     magnet_link = html.fromstring(magnet_response).xpath('//li/a/@href')[29]
 
     return magnet_link
-
-
-
-
-
-
-
-
 
 
 

--- a/cthulhu
+++ b/cthulhu
@@ -229,7 +229,7 @@ def select_torrent(results, display_count):
         display_count = len(results)
     
     # display data to user
-    print('\033[0m ID\t    S/L\t\tSize\t\tTorrent name\033[0m')
+    print('\033[1m ID\t    S/L\t\tSize\t\tTorrent name\033[0m')
     title_width = 0
     if os.get_terminal_size()[0] > 40:
         title_width = os.get_terminal_size()[0]-41
@@ -409,7 +409,7 @@ class Nyaa:
             exit()
 
         for i in range(len(titles)):
-            packed_data.append([titles[i], links[i], upload_dates[i], seeders[i], leechers[i], file_sizes[i]])
+            packed_data.append([titles[i], links[i], upload_dates[i], int(seeders[i]), int(leechers[i]), file_sizes[i]])
 
         # sort by seeder count
         sorted_data = sorted(packed_data, key=itemgetter(3), reverse=True)

--- a/cthulhu
+++ b/cthulhu
@@ -30,9 +30,6 @@ except ImportError:
     print('error: lxml is not installed (hint: pip3 install lxml)')
     exit()
 
-# can be changed to a mirror, might automate switching mirrors if 
-# server doesn't respond or something
-
 responses = []
 
 def main():
@@ -216,10 +213,12 @@ def parse_args(args):
     return (options, query, source)
 
 def get_source(source_name):
+    
     if source_name == '1337x':
         source = ThirteenThirtySevenX()
     elif source_name == 'nyaa':
         source = Nyaa()
+
     print('\nSource: '+ source_name)
     return source
 


### PR DESCRIPTION
Refactored code to allow for adding new sources. They can be added as new classes and must contain `get_responses()`, `parse_responses()`, and `get_magnet_link()` functions.

I also removed filter flags since they are not source-agnostic, but I might re-add them later.

Sources can be selected using  `--source` or `-s` flags.

Usage:
`cthulhu --source <source> [other options] [query]`

Current available sources:
- 1337x (default)
- Nyaa